### PR TITLE
Add predictSafeAddress

### DIFF
--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^5.6.0",
+    "@safe-global/safe-deployments": "^1.37.42",
     "@wdk-safe-global/protocol-kit": "^6.0.8",
     "@safe-global/safe-modules-deployments": "^2.2.8",
     "@safe-global/types-kit": "^2.0.1",

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -36,7 +36,8 @@ import {
   keccak256,
   slice,
   encodeAbiParameters,
-  parseAbiParameters
+  parseAbiParameters,
+  pad
 } from 'viem'
 import BaseSafeOperation from '@wdk-safe-global/relay-kit/packs/safe-4337/BaseSafeOperation'
 import SafeOperationFactory from '@wdk-safe-global/relay-kit/packs/safe-4337/SafeOperationFactory'
@@ -80,14 +81,33 @@ const MAX_ERC20_AMOUNT_TO_APPROVE =
 const EQ_OR_GT_1_4_1 = '>=1.4.1'
 
 const SAFE_PROXY_CREATION_CODES = {
-  // Early versions (1.0.0 - 1.2.0) use the older proxy creation code
-  //Note: legacy code is for L1 not L2, we can just delete it or keep it in case we want to support other versions in the future
-  legacy:
-    '0x608060405234801561001057600080fd5b506040516020806101a88339810180604052602081101561003057600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100c7576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260248152602001806101846024913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050606e806101166000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054163660008037600080366000845af43d6000803e6000811415603d573d6000fd5b3d6000f3fea165627a7a723058201e7d648b83cfac072cbccefc2ffc62a6999d4a050ee87a721942de1da9670db80029496e76616c6964206d617374657220636f707920616464726573732070726f7669646564',
-  // Newer versions (1.3.0+) use the updated proxy creation code for L2
   latest:
-    '0x608060405234801561001057600080fd5b506040516101e63803806101e68339818101604052602081101561003357600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100ca576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260228152602001806101c46022913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505060ab806101196000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea264697066735822122003d1488ee65e08fa41e58e888a9865554c535f2c77126a82cb4c0f917f31441364736f6c63430007060033496e76616c69642073696e676c65746f6e20616464726573732070726f7669646564'
+    '0x608060405234801561001057600080fd5b506040516101e63803806101e68339818101604052602081101561003357600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100ca576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260228152602001806101c46022913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505060ab806101196000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea264697066735822122003d1488ee65e08fa41e58e888a9865554c535f2c77126a82cb4c0f917f31441364736f6c63430007060033496e76616c69642073696e676c65746f6e20616464726573732070726f7669646564',
+  zkSync: {
+    latest:
+      '0x0000000000000000000000000000000000000000000000000000000000000000000000000100003b6cfa15bd7d1cae1c9c022074524d7785d34859ad0576d8fab4305d4f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  }
 } as const
+
+const ZKSYNC_CREATE2_PREFIX = '0x2020dba91b30cc0006188af794c2fb30dd8520db7e2c088b7fc7c103c00ca494'
+const ZKSYNC_SAFE_PROXY_DEPLOYED_BYTECODE: { [version: string]: { deployedBytecodeHash: Hash } } = {
+  '1.3.0': {
+    deployedBytecodeHash: '0x0100004124426fb9ebb25e27d670c068e52f9ba631bd383279a188be47e3f86d'
+  },
+  '1.4.1': {
+    deployedBytecodeHash: '0x0100003b6cfa15bd7d1cae1c9c022074524d7785d34859ad0576d8fab4305d4f'
+  }
+}
+
+function zkSyncCreate2Address(from: string, safeVersion: string, salt: Hex, input: Hex): string {
+  const bytecodeHash = ZKSYNC_SAFE_PROXY_DEPLOYED_BYTECODE[safeVersion]?.deployedBytecodeHash
+  if (!bytecodeHash) throw new Error(`Unsupported Safe version for zkSync: ${safeVersion}`)
+  const inputHash = keccak256(input)
+  const addressBytes = keccak256(
+    concat([ZKSYNC_CREATE2_PREFIX, pad(asHex(from)), salt, bytecodeHash, inputHash])
+  ).slice(26)
+  return `0x${addressBytes}`
+}
 
 /**
  * Gets the Safe deployment information (version, factory, singleton).
@@ -176,23 +196,11 @@ function isZkSyncChain(chainId: bigint | number): boolean {
  * @returns {`0x${string}`} The proxy creation bytecode for the given Safe version.
  * @throws {Error} If called for a zkSync chain.
  */
-function getProxyCreationCode(safeVersion: string, chainId?: bigint | number): `0x${string}` {
+function getProxyCreationCode(chainId?: bigint | number): `0x${string}` {
   if (chainId && isZkSyncChain(chainId)) {
-    // TODO: implement zkSync
-    throw new Error(
-      `zkSync chains (${chainId}) use different CREATE2 mechanics. Use predictSafeAddressWithChainId for zkSync support.`
-    )
+    return SAFE_PROXY_CREATION_CODES.zkSync.latest
   }
-
-  const version = safeVersion.split('.')
-  const major = parseInt(version[0])
-  const minor = parseInt(version[1])
-
-  if (major === 1 && minor <= 2) {
-    return SAFE_PROXY_CREATION_CODES.legacy
-  } else {
-    return SAFE_PROXY_CREATION_CODES.latest
-  }
+  return SAFE_PROXY_CREATION_CODES.latest
 }
 
 /**
@@ -1107,10 +1115,6 @@ export class Safe4337Pack extends RelayKitBasePack<{
   }): string {
     const chainIdBigInt = BigInt(chainId)
 
-    if (isZkSyncChain(chainId)) {
-      throw new Error('zkSync not yet supported.')
-    }
-
     const { factoryAddress, singletonAddress } = getSafeDeploymentInfo(chainIdBigInt, safeVersion)
 
     const network = chainIdBigInt.toString()
@@ -1172,10 +1176,15 @@ export class Safe4337Pack extends RelayKitBasePack<{
     const encodedNonce = encodeAbiParameters(parseAbiParameters('uint256'), [BigInt(saltNonce)])
     const salt = keccak256(concat([initializerHash as `0x${string}`, encodedNonce]))
 
-    const proxyCreationCode = getProxyCreationCode(safeVersion, chainIdBigInt)
+    const proxyCreationCode = getProxyCreationCode(chainIdBigInt)
 
     const checksummedSingletonAddress = getAddress(singletonAddress)
     const input = encodeAbiParameters(parseAbiParameters('address'), [checksummedSingletonAddress])
+
+    if (isZkSyncChain(chainId)) {
+      const proxyAddress = zkSyncCreate2Address(factoryAddress, safeVersion, salt, asHex(input))
+      return getAddress(proxyAddress)
+    }
     const initCode = concat([proxyCreationCode, asHex(input)])
 
     const hash = keccak256(

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -1,4 +1,4 @@
-import { getAddress, toHex } from 'viem'
+import { getAddress, toHex, isHex } from 'viem'
 import semverSatisfies from 'semver/functions/satisfies.js'
 import Safe, {
   EthSafeSignature,
@@ -6,8 +6,10 @@ import Safe, {
   getMultiSendContract,
   PasskeyClient,
   SafeProvider,
-  generateOnChainIdentifier
+  generateOnChainIdentifier,
+  SafeAccountConfig
 } from '@wdk-safe-global/protocol-kit'
+import { SafeVersion } from '@safe-global/types-kit'
 import { RelayKitBasePack } from '@wdk-safe-global/relay-kit/RelayKitBasePack'
 import {
   OperationType,
@@ -21,7 +23,21 @@ import {
   getSafe4337ModuleDeployment,
   getSafeWebAuthnShareSignerDeployment
 } from '@safe-global/safe-modules-deployments'
-import { Hash, encodeFunctionData, zeroAddress, Hex, concat } from 'viem'
+import {
+  getSafeL2SingletonDeployment,
+  getProxyFactoryDeployment
+} from '@safe-global/safe-deployments'
+import {
+  Hash,
+  encodeFunctionData,
+  zeroAddress,
+  Hex,
+  concat,
+  keccak256,
+  slice,
+  encodeAbiParameters,
+  parseAbiParameters
+} from 'viem'
 import BaseSafeOperation from '@wdk-safe-global/relay-kit/packs/safe-4337/BaseSafeOperation'
 import SafeOperationFactory from '@wdk-safe-global/relay-kit/packs/safe-4337/SafeOperationFactory'
 import {
@@ -51,10 +67,230 @@ import {
 } from '@wdk-safe-global/relay-kit/packs/safe-4337/utils'
 import { PimlicoFeeEstimator } from '@wdk-safe-global/relay-kit/packs/safe-4337/estimators/pimlico/PimlicoFeeEstimator'
 
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const EMPTY_DATA = '0x'
+
+function asHex(hex?: string): Hex {
+  return isHex(hex) ? (hex as Hex) : (`0x${hex}` as Hex)
+}
+
 const MAX_ERC20_AMOUNT_TO_APPROVE =
   0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn
 
 const EQ_OR_GT_1_4_1 = '>=1.4.1'
+
+const SAFE_PROXY_CREATION_CODES = {
+  // Early versions (1.0.0 - 1.2.0) use the older proxy creation code
+  //Note: legacy code is for L1 not L2, we can just delete it or keep it in case we want to support other versions in the future
+  legacy:
+    '0x608060405234801561001057600080fd5b506040516020806101a88339810180604052602081101561003057600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100c7576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260248152602001806101846024913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050606e806101166000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054163660008037600080366000845af43d6000803e6000811415603d573d6000fd5b3d6000f3fea165627a7a723058201e7d648b83cfac072cbccefc2ffc62a6999d4a050ee87a721942de1da9670db80029496e76616c6964206d617374657220636f707920616464726573732070726f7669646564',
+  // Newer versions (1.3.0+) use the updated proxy creation code for L2
+  latest:
+    '0x608060405234801561001057600080fd5b506040516101e63803806101e68339818101604052602081101561003357600080fd5b8101908080519060200190929190505050600073ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614156100ca576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260228152602001806101c46022913960400191505060405180910390fd5b806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505060ab806101196000396000f3fe608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea264697066735822122003d1488ee65e08fa41e58e888a9865554c535f2c77126a82cb4c0f917f31441364736f6c63430007060033496e76616c69642073696e676c65746f6e20616464726573732070726f7669646564'
+} as const
+
+/**
+ * Gets the Safe deployment information (version, factory, singleton).
+ * This helper function gets the Safe core version and contract addresses
+ * based on the chain ID and Safe version.
+ *
+ * @param {bigint | number} chainId - The chain ID
+ * @param {string} safeVersion - The Safe core version to use
+ * @returns {Object} Object containing safeVersion, factoryAddress, and singletonAddress
+ * @throws {Error} If no deployment information is found for the chain ID and version
+ */
+function getSafeDeploymentInfo(
+  chainId: bigint | number,
+  safeVersion: string
+): {
+  safeVersion: string
+  factoryAddress: string
+  singletonAddress: string
+} {
+  const singletonDeployment = getSafeL2SingletonDeployment({
+    version: safeVersion as SafeVersion,
+    released: true
+  })
+
+  const factoryDeployment = getProxyFactoryDeployment({
+    version: safeVersion as SafeVersion,
+    released: true
+  })
+
+  if (!singletonDeployment) {
+    throw new Error(`No Safe singleton deployment found for version ${safeVersion}`)
+  }
+
+  if (!factoryDeployment) {
+    throw new Error(`No Safe proxy factory deployment found for version ${safeVersion}`)
+  }
+
+  const chainIdStr = chainId.toString()
+  const singletonAddress = singletonDeployment.networkAddresses[chainIdStr]
+  const factoryAddress = factoryDeployment.networkAddresses[chainIdStr]
+
+  if (!singletonAddress) {
+    throw new Error(
+      `No Safe singleton address found for chain ID ${chainId} and version ${safeVersion}`
+    )
+  }
+
+  if (!factoryAddress) {
+    throw new Error(
+      `No Safe proxy factory address found for chain ID ${chainId} and version ${safeVersion}`
+    )
+  }
+
+  return {
+    safeVersion,
+    factoryAddress,
+    singletonAddress
+  }
+}
+
+/**
+ * Detects if a chain is zkSync.
+ *
+ * @param {bigint | number} chainId - The chain ID to check.
+ * @returns {boolean} True if the provided chain is a zkSync network; otherwise false.
+ */
+function isZkSyncChain(chainId: bigint | number): boolean {
+  const ZKSYNC_CHAIN_IDS = new Set([
+    324, // zkSync Era mainnet
+    300, // zkSync Era testnet
+    280, // zkSync Era localnet
+    232 // zkSync Era internal testnet
+  ])
+  return ZKSYNC_CHAIN_IDS.has(Number(chainId))
+}
+
+/**
+ * Returns the Safe Proxy creation bytecode for the provided Safe version on EVM chains.
+ *
+ * - Versions 1.0.0 - 1.2.0 use the legacy bytecode.
+ * - Versions 1.3.0+ use the latest bytecode.
+ * - zkSync chains are not supported by this function (different CREATE2 mechanics).
+ *
+ * @param {string} safeVersion - The Safe core version used to select the bytecode.
+ * @param {bigint | number} [chainId] - Optional chain ID; if a zkSync chain is detected, an error is thrown.
+ * @returns {`0x${string}`} The proxy creation bytecode for the given Safe version.
+ * @throws {Error} If called for a zkSync chain.
+ */
+function getProxyCreationCode(safeVersion: string, chainId?: bigint | number): `0x${string}` {
+  if (chainId && isZkSyncChain(chainId)) {
+    // TODO: implement zkSync
+    throw new Error(
+      `zkSync chains (${chainId}) use different CREATE2 mechanics. Use predictSafeAddressWithChainId for zkSync support.`
+    )
+  }
+
+  const version = safeVersion.split('.')
+  const major = parseInt(version[0])
+  const minor = parseInt(version[1])
+
+  if (major === 1 && minor <= 2) {
+    return SAFE_PROXY_CREATION_CODES.legacy
+  } else {
+    return SAFE_PROXY_CREATION_CODES.latest
+  }
+}
+
+/**
+ * Encodes the Safe setup initializer data synchronously.
+ *
+ * Produces the exact calldata used by Safe deployment, matching version-specific ABIs:
+ * - Safe 1.0.0: setup(address[] _owners, uint256 _threshold, address to, bytes data, address paymentToken, uint256 payment, address paymentReceiver)
+ * - Safe 1.1.0+: setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver)
+ *
+ * @param {SafeAccountConfig} safeAccountConfig - The configuration used for the Safe setup transaction.
+ * @param {string} safeVersion - The Safe core version used to select the correct ABI.
+ * @returns {string} Hex-encoded calldata for the Safe setup function.
+ */
+function encodeSetupCallDataSync(
+  safeAccountConfig: SafeAccountConfig,
+  safeVersion: string
+): string {
+  const {
+    owners,
+    threshold,
+    to = ZERO_ADDRESS,
+    data = EMPTY_DATA,
+    fallbackHandler = ZERO_ADDRESS,
+    paymentToken = ZERO_ADDRESS,
+    payment = 0,
+    paymentReceiver = ZERO_ADDRESS
+  } = safeAccountConfig
+
+  const version = safeVersion.split('.')
+  const major = parseInt(version[0])
+  const minor = parseInt(version[1])
+
+  if (major === 1 && minor === 0) {
+    const setupData = encodeFunctionData({
+      abi: [
+        {
+          inputs: [
+            { name: '_owners', type: 'address[]' },
+            { name: '_threshold', type: 'uint256' },
+            { name: 'to', type: 'address' },
+            { name: 'data', type: 'bytes' },
+            { name: 'paymentToken', type: 'address' },
+            { name: 'payment', type: 'uint256' },
+            { name: 'paymentReceiver', type: 'address' }
+          ],
+          name: 'setup',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        }
+      ],
+      functionName: 'setup',
+      args: [
+        owners,
+        BigInt(threshold),
+        to as `0x${string}`,
+        data as `0x${string}`,
+        paymentToken as `0x${string}`,
+        BigInt(payment),
+        paymentReceiver as `0x${string}`
+      ]
+    })
+    return setupData
+  } else {
+    const setupData = encodeFunctionData({
+      abi: [
+        {
+          inputs: [
+            { name: '_owners', type: 'address[]' },
+            { name: '_threshold', type: 'uint256' },
+            { name: 'to', type: 'address' },
+            { name: 'data', type: 'bytes' },
+            { name: 'fallbackHandler', type: 'address' },
+            { name: 'paymentToken', type: 'address' },
+            { name: 'payment', type: 'uint256' },
+            { name: 'paymentReceiver', type: 'address' }
+          ],
+          name: 'setup',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function'
+        }
+      ],
+      functionName: 'setup',
+      args: [
+        owners,
+        BigInt(threshold),
+        to as `0x${string}`,
+        data as `0x${string}`,
+        fallbackHandler as `0x${string}`,
+        paymentToken as `0x${string}`,
+        BigInt(payment),
+        paymentReceiver as `0x${string}`
+      ]
+    })
+    return setupData
+  }
+}
 
 /**
  * Safe4337Pack class that extends RelayKitBasePack.
@@ -838,5 +1074,115 @@ export class Safe4337Pack extends RelayKitBasePack<{
 
   getOnchainIdentifier(): string {
     return this.#onchainIdentifier
+  }
+
+  /**
+   * Predicts the address of a Safe account and returns it.
+   *
+   * Implements the CREATE2 derivation using the Safe Proxy Factory:
+   * address = keccak256(0xff ++ factoryAddress ++ salt ++ keccak256(initCode))[12:]
+   *
+   * @param {Object} config - The prediction configuration.
+   * @param {number} config.threshold - The number of owners required to execute a transaction.
+   * @param {string} config.owner - The owner address for the Safe account.
+   * @param {string} config.saltNonce - 0x-prefixed 32-byte salt used for CREATE2.
+   * @param {string} config.entryPointAddress - The ERC-4337 entrypoint address.
+   * @param {bigint | number} config.chainId - The chain ID for deployment.
+   * @returns {string} The predicted Safe address (checksumed hex string).
+   */
+  static predictSafeAddress({
+    threshold,
+    owner,
+    saltNonce,
+    chainId,
+    safeVersion,
+    safeModulesVersion
+  }: {
+    threshold: number
+    owner: string
+    saltNonce: string
+    chainId: bigint | number
+    safeVersion: string
+    safeModulesVersion: string
+  }): string {
+    const chainIdBigInt = BigInt(chainId)
+
+    if (isZkSyncChain(chainId)) {
+      throw new Error('zkSync not yet supported.')
+    }
+
+    const { factoryAddress, singletonAddress } = getSafeDeploymentInfo(chainIdBigInt, safeVersion)
+
+    const network = chainIdBigInt.toString()
+    const safe4337ModuleDeployment = getSafe4337ModuleDeployment({
+      released: true,
+      version: safeModulesVersion,
+      network
+    })
+    const safe4337ModuleAddress = safe4337ModuleDeployment?.networkAddresses[network]
+
+    if (!safe4337ModuleAddress) {
+      throw new Error(
+        `Safe4337Module not available for chain ${network} and modules version ${safeModulesVersion}`
+      )
+    }
+
+    const safeModuleSetupDeployment = getSafeModuleSetupDeployment({
+      released: true,
+      version: safeModulesVersion,
+      network
+    })
+    const safeModulesSetupAddress = safeModuleSetupDeployment?.networkAddresses[network]
+
+    if (!safeModulesSetupAddress) {
+      throw new Error(
+        `SafeModuleSetup not available for chain ${network} and modules version ${safeModulesVersion}`
+      )
+    }
+
+    const enable4337ModuleTransaction = {
+      to: safeModulesSetupAddress,
+      value: '0',
+      data: encodeFunctionData({
+        abi: ABI,
+        functionName: 'enableModules',
+        args: [[safe4337ModuleAddress]]
+      }),
+      operation: OperationType.DelegateCall
+    }
+
+    const deploymentTo = enable4337ModuleTransaction.to
+    const deploymentData = enable4337ModuleTransaction.data
+
+    const safeAccountConfig: SafeAccountConfig = {
+      owners: [owner],
+      threshold,
+      to: deploymentTo,
+      data: deploymentData,
+      fallbackHandler: safe4337ModuleAddress,
+      paymentToken: '0x0000000000000000000000000000000000000000',
+      payment: 0,
+      paymentReceiver: '0x0000000000000000000000000000000000000000'
+    }
+
+    const initializer = encodeSetupCallDataSync(safeAccountConfig, safeVersion)
+
+    const initializerHash = keccak256(initializer as `0x${string}`)
+
+    const encodedNonce = encodeAbiParameters(parseAbiParameters('uint256'), [BigInt(saltNonce)])
+    const salt = keccak256(concat([initializerHash as `0x${string}`, encodedNonce]))
+
+    const proxyCreationCode = getProxyCreationCode(safeVersion, chainIdBigInt)
+
+    const checksummedSingletonAddress = getAddress(singletonAddress)
+    const input = encodeAbiParameters(parseAbiParameters('address'), [checksummedSingletonAddress])
+    const initCode = concat([proxyCreationCode, asHex(input)])
+
+    const hash = keccak256(
+      concat(['0xff' as `0x${string}`, factoryAddress as `0x${string}`, salt, keccak256(initCode)])
+    )
+
+    const address = slice(hash, 12)
+    return getAddress(address)
   }
 }


### PR DESCRIPTION
## What it solves
Resolves #

Adds a static sync function predictSafeAddress to work specifically for our use case.

Due to our use case, I've created this with the following assumptions:

1. We always use v1.4.1 -I made safeVersion a param just in case, so I hardcode 1.4.1 on the wdk.
2. We always use Safe L2 singleton over L1.
3. The fallback handler is always the safeModule address due to using L2.
4. The proxyCreationCode is the only thing hardcoded, as this is the same across all contracts.

The above was determined by going through the options we pass in upon Safe.init() in the WDK, and understanding how the Safe SDK functions.
I mirrored the Protocol Kit's async solution. Our solution remains static and synchronous.
As for the proxyCreationCode, this is different depending on all versions of Safe and Safe 1.3.0 and above. But the metadata also slightly differs for L1 and L2 singletons, so we have hardcoded the up to date L2 version. I created a script to confirm this is exactly the same across multiple different chains.
ZKsync support is implemented as well, and I used the same discovery script for getting the proxyCreationCode to verify it's unique code as well. Zksync needs testing.


## How this PR fixes it
